### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/AhetejazDevEnv/fb64ec77-fc00-4cc4-b208-628407f69652/9604f8cb-7d4f-469a-bd2d-3b5705b90616/_apis/work/boardbadge/00f2219e-395d-4943-8eda-d9479134d9dc)](https://dev.azure.com/AhetejazDevEnv/fb64ec77-fc00-4cc4-b208-628407f69652/_boards/board/t/9604f8cb-7d4f-469a-bd2d-3b5705b90616/Microsoft.RequirementCategory)
 ## Microsoft Open Source Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#835](https://dev.azure.com/AhetejazDevEnv/fb64ec77-fc00-4cc4-b208-628407f69652/_workitems/edit/835). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.